### PR TITLE
[MAJOR] Attributions and environment variable update

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Calls `recorder.reset()` internally.
 
 Resets nock state & state of recorder.
 
-#### `recorder.mode()`
+#### `recorder.getMode()`
 
 Get the recorder mode.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Nocktor
 ====
 (Nock doctor)
 
-A prescription for using Nock's recording capabilities to heal your tests' ailing mock data. Use Nocktor to create a single set of tests that can be run in `live`, `record` or `replay` mode. This library applies functional testing best practices from @walmartlabs to provide a simple API for recording and replaying mock data. 
+A prescription for using Nock's recording capabilities to heal your tests' ailing mock data. Use Nocktor to create a single set of tests that can be run in `live`, `record` or `replay` mode. This library applies functional testing best practices from @walmartlabs to provide a simple API for recording and replaying mock data.
 
 ## Example
 
@@ -39,7 +39,7 @@ describe('Api Tests', () => {
 NOCK_RECORDER=live mocha ./test/api.spec.js --grep "api#fetchUsers()"
 # Test spec against live API, while recording responses to disk
 NOCK_RECORDER=record mocha ./test/api.spec.js --grep "api#fetchUsers()"
-# Test spec against recorded responses 
+# Test spec against recorded responses
 NOCK_RECORDER=replay mocha ./test/api.spec.js --grep "api#fetchUsers()"
 # Track recorded responses (mocks) in version control
 git a ./test/recorded-data/api-fetch-users-happy-path-records.json
@@ -97,4 +97,23 @@ For more complex request flows the user may still access nock directly so there'
 
 Nocktor introduces little functionality of its own, but provides a set of useful helper functions that reduce boilerplate and dictate test design patterns that have proven quite successful for us.
 
-Finally, nock is just much more pleasant to use with Nocktor - or at least that is what we have found at WalmartLabs!
+Finally, Nock is just much more pleasant to use with Nocktor - or at least that is what we have found at WalmartLabs!
+
+## Attributions
+This module was born inside @walmartlabs, and commit history was wiped out when we ported it to a public module.
+These fine engineers worked very hard on this module, and they should get credit for it.
+
+### Ian Walker Sperber (@ianwsperber) -
+Original inventor and author of this module. Also a contributor to Nock.
+
+### Christopher Crewdson (@chriscrewdson) -
+Current maintainer and responsible for porting this library for public use.
+
+### Kyle Schatler (@kschat) -
+Past contributor when this module was internal
+
+### Kevin Stephens (@kevinmstephens) -
+Past contributor when this module was internal
+
+### Steve Slayden (@steveslayden) -
+Past contributor when this module was internal

--- a/README.md
+++ b/README.md
@@ -36,11 +36,11 @@ describe('Api Tests', () => {
 
 ```sh
 # Test spec against live API
-NOCK_RECORDER=live mocha ./test/api.spec.js --grep "api#fetchUsers()"
+NOCKTOR_MODE=live mocha ./test/api.spec.js --grep "api#fetchUsers()"
 # Test spec against live API, while recording responses to disk
-NOCK_RECORDER=record mocha ./test/api.spec.js --grep "api#fetchUsers()"
+NOCKTOR_MODE=record mocha ./test/api.spec.js --grep "api#fetchUsers()"
 # Test spec against recorded responses
-NOCK_RECORDER=replay mocha ./test/api.spec.js --grep "api#fetchUsers()"
+NOCKTOR_MODE=replay mocha ./test/api.spec.js --grep "api#fetchUsers()"
 # Track recorded responses (mocks) in version control
 git a ./test/recorded-data/api-fetch-users-happy-path-records.json
 ```
@@ -63,7 +63,7 @@ Must call `recorder.stop()` before calling `recorder.start()` again.
 
 `tag: string`: Unique tag which will be used to generate filename for record
 
-`options.mode: ['replay'|'record'|'live']`: Overrides the default mode. Default mode is `replay`, unless overriden by the environment variables `NOCK_RECORDER` or `TEST_MODE`.
+`options.mode: ['replay'|'record'|'live']`: Overrides the default mode. Default mode is `replay`, unless overriden by the environment variable `NOCKTOR_MODE`.
 
 `options.recordReqHeaders: boolean`: Used in `record` mode. If true, tells nock to record request headers. Off be default, since request headers often include timestamps.
 
@@ -85,7 +85,20 @@ Resets nock state & state of recorder.
 
 Get the recorder mode.
 
-Returns the mode uses for the current run if we're in a recording. Returns the current default mode otherwise.
+Returns the mode uses for the current run if we're in a recording.
+Throws an exception if the recorder is not started.
+
+#### `recorder.getModesEnum()`
+
+Returns an object containing the available modes to run Nocktor in:
+```
+{
+  REPLAY: "replay",
+  LIVE: "live",
+  RECORD: "record",
+  DEFAULT: "replay"
+}
+```
 
 ## But Why?
 
@@ -101,7 +114,7 @@ Finally, Nock is just much more pleasant to use with Nocktor - or at least that 
 
 ## Attributions
 This module was born inside @walmartlabs, and commit history was wiped out when we ported it to a public module.
-These fine engineers worked very hard on this module, and they should get credit for it.
+These following engineers worked very hard on this module, and they should get credit for it.
 
 ### Ian Walker Sperber (@ianwsperber) -
 Original inventor and author of this module. Also a contributor to Nock.

--- a/lib/index.js
+++ b/lib/index.js
@@ -179,5 +179,6 @@ module.exports = {
   stop,
   reset,
   getMode,
-  getModesEnum: () => Object.assign({}, MODES)
+  getModesEnum: () => Object.assign({}, MODES),
+  nock
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -21,13 +21,12 @@ const path = require("path");
 const fs = require("fs");
 const assert = require("assert");
 
-const REPLAY_MODE = "replay";
-const LIVE_MODE = "live";
-const RECORD_MODE = "record";
-
-module.exports.RECORD_MODE = RECORD_MODE;
-module.exports.LIVE_MODE = LIVE_MODE;
-module.exports.REPLAY_MODE = REPLAY_MODE;
+const MODES = {
+  REPLAY: "replay",
+  LIVE: "live",
+  RECORD: "record",
+  DEFAULT: "replay"
+};
 
 const state = {
   running: false,
@@ -61,7 +60,7 @@ const replay = (dir, tag, redefine) => {
     nockDefs = nock.loadDefs(getRecordFilename(dir, tag));
   } catch (err) {
     // eslint-disable-next-line max-len
-    err.message = `Nock recorder failure - could not load definitions. Have you created a recording yet?\n\n${err.message}`;
+    err.message = `Nocktor failure - could not load definitions. Have you created a recording yet?\n\n${err.message}`;
     throw err;
   }
 
@@ -79,11 +78,11 @@ const stop = () => {
 
   if (state.running && !state.stop) {
     // eslint-disable-next-line max-len
-    throw new Error("Nock recorder failure - unexpected recording without having set stop method");
+    throw new Error("Nocktor failure - unexpected recording without having set stop method");
   }
 
   // eslint-disable-next-line max-len
-  throw new Error("Nock recorder failure - can\'t stop, nock recorder is not running!");
+  throw new Error("Nocktor failure - can\'t stop, Nocktor is not running!");
 };
 
 const reset = () => {
@@ -98,9 +97,25 @@ const reset = () => {
   nock.activate();
 };
 
-const modeByEnv = () => process.env.NOCK_RECORDER || process.env.TEST_MODE || REPLAY_MODE;
+const modeByEnv = () => {
+  return process.env.NOCKTOR_MODE;
+};
 
-const mode = () => state.mode || modeByEnv();
+const setMode = mode => {
+  const acceptableModes = Object.values(MODES);
+  if (!acceptableModes.includes(mode)) {
+    throw new Error(`Nocktor failure - unexpected mode '${mode}'. Must be one of ${JSON.stringify(acceptableModes)}`);
+  }
+
+  state.mode = mode;
+};
+
+const getMode = () => {
+  if (!state.mode) {
+    throw new Error(`Nocktor failure - attempt to access mode before starting recorder`);
+  }
+  return state.mode;
+};
 
 /**
  * Start nock behavior
@@ -117,28 +132,29 @@ const start = (dir, tag, opts) => {
   assert(dir, "Missing tag data directory");
   assert(tag, "Missing tag name");
 
-  assert(!state.running, "Nock recorder already running");
+  assert(!state.running, "Nocktor already running");
 
   state.running = true;
-  state.mode = options.mode || modeByEnv();
+  setMode(options.mode || modeByEnv() || MODES.DEFAULT);
+
   let nocks;
 
   // Safety check
   nock.enableNetConnect();
 
-  if (state.mode === RECORD_MODE) {
+  if (getMode() === MODES.RECORD) {
     record(options.recordReqHeaders);
-  } else if (state.mode !== LIVE_MODE) { // Unknown modes run as replay
+  } else if (getMode() === MODES.REPLAY) { // Unknown modes run as replay
     nock.disableNetConnect(); // Ensure we are not allowing requests unexpectedly
     nocks = replay(dir, tag, options.redefine);
   }
 
   state.stop = () => {
     const records = nock.recorder.play();
-    const stateMode = state.mode;
+    const mode = getMode();
     reset();
 
-    if (stateMode !== RECORD_MODE) {
+    if (mode !== MODES.RECORD) {
       return null;
     }
 
@@ -150,7 +166,7 @@ const start = (dir, tag, opts) => {
       fs.writeFileSync(filename, stringified);
     } catch (err) {
       // eslint-disable-next-line max-len
-      err.message = `Nock recorder failure - failed to persist nock records: ${err.message}`;
+      err.message = `Nocktor failure - failed to persist nock records: ${err.message}`;
       throw err;
     }
 
@@ -164,5 +180,6 @@ module.exports = {
   start,
   stop,
   reset,
-  mode
+  mode: getMode,
+  getModesEnum: () => Object.assign({}, MODES)
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -97,9 +97,7 @@ const reset = () => {
   nock.activate();
 };
 
-const modeByEnv = () => {
-  return process.env.NOCKTOR_MODE;
-};
+const getModeByEnv = () => process.env.NOCKTOR_MODE;
 
 const setMode = mode => {
   const acceptableModes = Object.values(MODES);
@@ -135,7 +133,7 @@ const start = (dir, tag, opts) => {
   assert(!state.running, "Nocktor already running");
 
   state.running = true;
-  setMode(options.mode || modeByEnv() || MODES.DEFAULT);
+  setMode(options.mode || getModeByEnv() || MODES.DEFAULT);
 
   let nocks;
 
@@ -180,6 +178,6 @@ module.exports = {
   start,
   stop,
   reset,
-  mode: getMode,
+  getMode,
   getModesEnum: () => Object.assign({}, MODES)
 };

--- a/test/unit/index.spec.js
+++ b/test/unit/index.spec.js
@@ -252,14 +252,14 @@ describe("Nocktor", () => {
     });
   });
 
-  describe("recorder#mode() @unit", () => {
+  describe("recorder#getgetMode() @unit", () => {
     it("should return the active mode if running", () => {
       ["live", "replay", "record"].forEach(mode => {
         recorder.start(dir, "foo", { mode });
-        expect(recorder.mode()).to.equal(mode);
+        expect(recorder.getMode()).to.equal(mode);
         recorder.stop();
         recorder.start(dir, "foo");
-        expect(recorder.mode(), "Mode returns to default").to.equal("replay");
+        expect(recorder.getMode(), "Mode returns to default").to.equal("replay");
         recorder.stop();
       });
     });
@@ -269,17 +269,17 @@ describe("Nocktor", () => {
         process.env.NOCKTOR_MODE = mode;
 
         recorder.start(dir, "foo");
-        expect(recorder.mode()).to.equal(mode);
+        expect(recorder.getMode()).to.equal(mode);
 
         recorder.stop();
         recorder.start(dir, "foo", { mode: "live" });
-        expect(recorder.mode(), "Active mode overrides defaults").to.equal("live");
+        expect(recorder.getMode(), "Active mode overrides defaults").to.equal("live");
 
         recorder.stop();
         delete process.env.NOCKTOR_MODE;
 
         recorder.start(dir, "foo");
-        expect(recorder.mode(), "Mode returns to default").to.equal("replay");
+        expect(recorder.getMode(), "Mode returns to default").to.equal("replay");
         recorder.stop();
 
       });
@@ -289,13 +289,13 @@ describe("Nocktor", () => {
       delete process.env.NOCKTOR_MODE;
 
       recorder.start(dir, "foo");
-      expect(recorder.mode()).to.equal("replay");
+      expect(recorder.getMode()).to.equal("replay");
       recorder.stop();
     });
 
     it("should throw if not running", () => {
       delete process.env.NOCKTOR_MODE;
-      expect(recorder.mode).to.throw(/Nocktor failure - attempt to access mode/);
+      expect(recorder.getMode).to.throw(/Nocktor failure - attempt to access mode/);
     });
   });
 

--- a/test/unit/index.spec.js
+++ b/test/unit/index.spec.js
@@ -316,4 +316,10 @@ describe("Nocktor", () => {
       expect(modesOne).to.not.equal(modesTwo);
     });
   });
+
+  describe("recorder#nock @unit", () => {
+    it("exports instance of nock used internally", () => {
+      expect(recorder.nock).to.equal(nock);
+    });
+  });
 });


### PR DESCRIPTION
## Addresses #5 
Attributions added.

## Addresses #4 
By exporting the instance of Nock used by Nocktor, developers can re-enable network passthrough for the hostname/port that their local API is running on. 

## Addresses #2 
Now that this repo is named `Nocktor`, the environment variables should match. The previous supported environment variables were `NOCK_RECORDER` and `TEST_MODE`. Rather than add yet another possible environment var, I think that we should use `NOCKTOR_MODE` exclusively. This will be a breaking change, but now is the time to do it, since the package was just made public.

Along with replacing the existing environment variables with `NOCKTOR_MODE`, I also refactored how the `mode` is handled so that the specified `mode` is validated (may only be one of `replay`, `record` and `live`). 
